### PR TITLE
Make code more idiomatic Rust and add some tests.

### DIFF
--- a/src/alert.rs
+++ b/src/alert.rs
@@ -32,24 +32,12 @@ pub struct AlertProps {
 
 #[component]
 pub fn Alert(props: AlertProps) -> Element {
-    let alert_color = if props.alert_color.is_some() {
-        props.alert_color.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
+    let alert_color = props.alert_color.unwrap_or_default();
+    let class = props.class.unwrap_or_default();
 
     let class = format!("{} {}", alert_color.to_string(), class);
 
     rsx!(
-        div {
-            class: "{class}",
-            {props.children},
-        }
+        div { class: "{class}", {props.children} }
     )
 }

--- a/src/avatar.rs
+++ b/src/avatar.rs
@@ -40,32 +40,25 @@ pub struct AvatarProps {
 
 #[component]
 pub fn Avatar(props: AvatarProps) -> Element {
-    let avatar_size = if props.avatar_size.is_some() {
-        props.avatar_size.unwrap()
-    } else {
-        Default::default()
-    };
+    let avatar_size = props.avatar_size.unwrap_or_default();
+
     let avatar_size = avatar_size.to_string();
 
-    let mut the_name = "?".to_string();
-    if let Some(name) = props.name {
-        the_name = if let Some(chr) = name.chars().next() {
-            chr.to_string()
-        } else {
-            "?".to_string()
-        };
-    }
+    // Get the first character of the name, or "?" if the name is empty
+    let the_name = props
+        .name
+        .as_deref()
+        .and_then(|n| n.chars().next())
+        .map_or("?".to_string(), |c| c.to_string());
 
     if let Some(image) = props.image_src {
         rsx!(
-            div {
-                class: "avatar",
-                div {
-                    class: "rounded {avatar_size.2}",
+            div { class: "avatar",
+                div { class: "rounded {avatar_size.2}",
                     img {
                         width: avatar_size.0,
                         height: avatar_size.1,
-                        src: image
+                        src: image,
                     }
                 }
             }
@@ -73,10 +66,8 @@ pub fn Avatar(props: AvatarProps) -> Element {
     } else {
         match props.avatar_type {
             Some(AvatarType::User) => rsx!(
-                div {
-                    class: "avatar",
-                    div {
-                        class: "rounded {avatar_size.2}",
+                div { class: "avatar",
+                    div { class: "rounded {avatar_size.2}",
                         svg {
                             "aria-hidden": true,
                             xmlns: "http://www.w3.org/2000/svg",
@@ -89,31 +80,19 @@ pub fn Avatar(props: AvatarProps) -> Element {
                                 rx: "12",
                                 width: "27",
                                 x: "0",
-                                y: "0"
+                                y: "0",
                             }
-                            g {
-                                fill: "#fff",
-                                opacity: ".5",
-                                circle {
-                                    cx: "13.5",
-                                    cy: "30",
-                                    r: "13"
-                                }
-                                circle {
-                                    cx: "13.5",
-                                    cy: "11",
-                                    r: "5"
-                                }
+                            g { fill: "#fff", opacity: ".5",
+                                circle { cx: "13.5", cy: "30", r: "13" }
+                                circle { cx: "13.5", cy: "11", r: "5" }
                             }
                         }
                     }
                 }
             ),
             Some(_) => rsx!(
-                div {
-                    class: "avatar",
-                    div {
-                        class: "rounded {avatar_size.2}",
+                div { class: "avatar",
+                    div { class: "rounded {avatar_size.2}",
                         svg {
                             "aria-hidden": true,
                             xmlns: "http://www.w3.org/2000/svg",
@@ -140,10 +119,8 @@ pub fn Avatar(props: AvatarProps) -> Element {
                 }
             ),
             None => rsx!(
-                div {
-                    class: "avatar",
-                    div {
-                        class: "rounded {avatar_size.2}",
+                div { class: "avatar",
+                    div { class: "rounded {avatar_size.2}",
                         svg {
                             "aria-hidden": true,
                             xmlns: "http://www.w3.org/2000/svg",

--- a/src/card.rs
+++ b/src/card.rs
@@ -39,21 +39,9 @@ pub struct CardHeadersProps {
 
 #[component]
 pub fn CardHeader(props: CardHeadersProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!("card-header flex items-center {}", class);
-
     rsx!(
-        div {
-            class: "{class}",
-            h3 {
-                class: "card-title overflow-hidden",
-                "{props.title}"
-            }
+        div { class: "card-header flex items-center {props.class.clone().unwrap_or_default()}",
+            h3 { class: "card-title overflow-hidden", "{props.title}" }
             {props.children}
         }
     )
@@ -67,16 +55,7 @@ pub struct CardBodyProps {
 
 #[component]
 pub fn CardBody(props: CardBodyProps) -> Element {
-    let class = if let Some(class) = props.class {
-        format!("card-body {}", class)
-    } else {
-        "card-body".to_string()
-    };
-
     rsx!(
-        div {
-            class: "{class}",
-            {props.children}
-        }
+        div { class: "card-body {props.class.clone().unwrap_or_default()}", {props.children} }
     )
 }

--- a/src/check_box.rs
+++ b/src/check_box.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
@@ -10,13 +12,13 @@ pub enum CheckBoxScheme {
     Danger,
 }
 
-impl CheckBoxScheme {
-    pub fn to_string(&self) -> &'static str {
+impl Display for CheckBoxScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CheckBoxScheme::Default => "checkbox-default",
-            CheckBoxScheme::Primary => "checkbox-primary",
-            CheckBoxScheme::Outline => "checkbox-outline",
-            CheckBoxScheme::Danger => "checkbox-warning",
+            CheckBoxScheme::Default => write!(f, "checkbox-default"),
+            CheckBoxScheme::Primary => write!(f, "checkbox-primary"),
+            CheckBoxScheme::Outline => write!(f, "checkbox-outline"),
+            CheckBoxScheme::Danger => write!(f, "checkbox-warning"),
         }
     }
 }
@@ -31,14 +33,14 @@ pub enum CheckBoxSize {
     Medium,
 }
 
-impl CheckBoxSize {
-    pub fn to_string(&self) -> &'static str {
+impl Display for CheckBoxSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CheckBoxSize::Default => "checkbox-sm",
-            CheckBoxSize::ExtraSmall => "checkbox-xs",
-            CheckBoxSize::Small => "checkbox-sm",
-            CheckBoxSize::Medium => "checkbox-md",
-            CheckBoxSize::Large => "checkbox-lg",
+            CheckBoxSize::Default => write!(f, "checkbox-sm"),
+            CheckBoxSize::Small => write!(f, "checkbox-sm"),
+            CheckBoxSize::ExtraSmall => write!(f, "checkbox-xs"),
+            CheckBoxSize::Large => write!(f, "checkbox-lg"),
+            CheckBoxSize::Medium => write!(f, "checkbox-md"),
         }
     }
 }
@@ -57,50 +59,77 @@ pub struct CheckBoxProps {
 
 #[component]
 pub fn CheckBox(props: CheckBoxProps) -> Element {
-    let checkbox_scheme = if props.checkbox_scheme.is_some() {
-        props.checkbox_scheme.unwrap()
-    } else {
-        Default::default()
-    };
+    let checkbox_scheme = props.checkbox_scheme.unwrap_or_default();
+    let checkbox_size = props.checkbox_size.unwrap_or_default();
+    let class = props.class.unwrap_or_default();
 
-    let checkbox_size = if props.checkbox_size.is_some() {
-        props.checkbox_size.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let checked = if let Some(checked) = props.checked {
-        if checked {
-            Some("checked")
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
-    let class = format!(
-        "checkbox {} {} {}",
-        class,
-        checkbox_scheme.to_string(),
-        checkbox_size.to_string()
-    );
+    let checked = props
+        .checked
+        .and_then(|checked| checked.then_some("checked"));
 
     rsx!(
         input {
             "type": "checkbox",
-            class: "{class}",
+            class: "checkbox {class} {checkbox_scheme} {checkbox_size}",
             id: props.id,
             name: props.name,
             value: props.value,
-            checked: checked,
-            {props.children},
+            checked,
+            {props.children}
         }
     )
+}
+
+#[test]
+fn test_check_box() {
+    let props = CheckBoxProps {
+        children: rsx!(),
+        name: "name".to_string(),
+        value: "value".to_string(),
+        checked: Some(true),
+        class: Some("custom".to_string()),
+        checkbox_size: Some(CheckBoxSize::Large),
+        checkbox_scheme: Some(CheckBoxScheme::Danger),
+        id: Some("id".to_string()),
+    };
+    let expected = r#"<input type="checkbox" class="checkbox custom checkbox-warning checkbox-lg" id="id" name="name" value="value" checked="checked"></input>"#;
+    let result = dioxus_ssr::render_element(CheckBox(props));
+    // println!("{}", result);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_check_box_default() {
+    let props = CheckBoxProps {
+        children: rsx!(),
+        name: "name".to_string(),
+        value: "value".to_string(),
+        checked: None,
+        class: None,
+        checkbox_size: None,
+        checkbox_scheme: None,
+        id: None,
+    };
+    let expected = r#"<input type="checkbox" class="checkbox  checkbox-default checkbox-sm" name="name" value="value"></input>"#;
+    let result = dioxus_ssr::render_element(CheckBox(props));
+    // println!("{}", result);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_check_box_checked_false() {
+    let props = CheckBoxProps {
+        children: rsx!(),
+        name: "name".to_string(),
+        value: "value".to_string(),
+        checked: Some(false),
+        class: None,
+        checkbox_size: None,
+        checkbox_scheme: None,
+        id: None,
+    };
+    let expected = r#"<input type="checkbox" class="checkbox  checkbox-default checkbox-sm" name="name" value="value"></input>"#;
+    let result = dioxus_ssr::render_element(CheckBox(props));
+    // println!("{}", result);
+    assert_eq!(result, expected);
 }

--- a/src/drop_down.rs
+++ b/src/drop_down.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
@@ -11,14 +13,14 @@ pub enum Direction {
     Right,
 }
 
-impl Direction {
-    pub fn to_string(&self) -> &'static str {
+impl Display for Direction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Direction::None => "",
-            Direction::Top => "dropdown-top",
-            Direction::Bottom => "dropdown-bottom",
-            Direction::Left => "dropdown-left",
-            Direction::Right => "dropdown-right",
+            Direction::None => write!(f, ""),
+            Direction::Top => write!(f, "dropdown-top"),
+            Direction::Bottom => write!(f, "dropdown-bottom"),
+            Direction::Left => write!(f, "dropdown-left"),
+            Direction::Right => write!(f, "dropdown-right"),
         }
     }
 }
@@ -36,52 +38,28 @@ pub struct DropDownProps {
 
 #[component]
 pub fn DropDown(props: DropDownProps) -> Element {
-    let direction = if let Some(direction) = props.direction {
-        direction.to_string()
-    } else {
-        Direction::default().to_string()
-    };
-
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
+    let direction = props.direction.unwrap_or_default();
 
     rsx!(
-        div {
-            class: "dropdown {class} {direction}",
+        div { class: "dropdown {props.class.clone().unwrap_or_default()} {direction}",
             label {
                 tabindex: "0",
                 class: "btn btn-default btn-sm m-1 w-full flex flex-nowrap justify-between",
                 "aria-haspopup": "true",
                 if let Some(img_src) = props.prefix_image_src {
-                        img {
-                            src: "{img_src}",
-                            class: "mr-2",
-                            width: "16"
-                        }
-                },
-                span {
-                    class: "truncate",
-                    "{props.button_text}"
+                    img { src: "{img_src}", class: "mr-2", width: "16" }
                 }
+                span { class: "truncate", "{props.button_text}" }
                 if let Some(img_src) = props.suffix_image_src {
-                        img {
-                            src: "{img_src}",
-                            class: "ml-2",
-                            width: "12"
-                        }
+                    img { src: "{img_src}", class: "ml-2", width: "12" }
                 } else if props.carat.is_some() && props.carat.unwrap() {
-                        div {
-                            class: "dropdown-caret"
-                        }
+                    div { class: "dropdown-caret" }
                 }
             }
             ul {
                 tabindex: "0",
                 class: "dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52 {direction}",
-                {props.children},
+                {props.children}
             }
         }
     )
@@ -98,11 +76,7 @@ pub struct DropDownLinkProps {
 
 #[component]
 pub fn DropDownLink(props: DropDownLinkProps) -> Element {
-    let class = if let Some(class) = props.class {
-        format!("dropdown-item {} ", class)
-    } else {
-        "dropdown-item".to_string()
-    };
+    let class = format!("dropdown-item {}", props.class.unwrap_or_default());
 
     if let Some(trigger) = &props.drawer_trigger {
         rsx!(
@@ -112,7 +86,7 @@ pub fn DropDownLink(props: DropDownLinkProps) -> Element {
                     "data-drawer-target": "{trigger}",
                     target: props.target,
                     href: "{props.href}",
-                    {props.children},
+                    {props.children}
                 }
             }
         )
@@ -123,7 +97,7 @@ pub fn DropDownLink(props: DropDownLinkProps) -> Element {
                     class: "{class}",
                     target: props.target,
                     href: "{props.href}",
-                    {props.children},
+                    {props.children}
                 }
             }
         )

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
@@ -10,13 +12,13 @@ pub enum InputType {
     Password,
 }
 
-impl InputType {
-    pub fn to_string(&self) -> &'static str {
+impl Display for InputType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InputType::Text => "text",
-            InputType::Number => "number",
-            InputType::Email => "email",
-            InputType::Password => "password",
+            InputType::Text => write!(f, "text"),
+            InputType::Number => write!(f, "number"),
+            InputType::Email => write!(f, "email"),
+            InputType::Password => write!(f, "password"),
         }
     }
 }
@@ -31,14 +33,14 @@ pub enum InputSize {
     Medium,
 }
 
-impl InputSize {
-    pub fn to_string(&self) -> &'static str {
+impl Display for InputSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InputSize::Default => "input-sm",
-            InputSize::ExtraSmall => "input-xs",
-            InputSize::Small => "input-sm",
-            InputSize::Large => "input-lg",
-            InputSize::Medium => "input-md",
+            InputSize::Default => write!(f, "input-sm"),
+            InputSize::ExtraSmall => write!(f, "input-xs"),
+            InputSize::Small => write!(f, "input-sm"),
+            InputSize::Large => write!(f, "input-lg"),
+            InputSize::Medium => write!(f, "input-md"),
         }
     }
 }
@@ -62,42 +64,22 @@ pub struct InputProps {
 
 #[component]
 pub fn Input(props: InputProps) -> Element {
-    let input_type = if props.input_type.is_some() {
-        props.input_type.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let input_size = if props.input_size.is_some() {
-        props.input_size.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let input_type = input_type.to_string();
-    let input_size = input_size.to_string();
-
-    let input_class = format!("{} {}", input_type, input_size);
+    let input_type = props.input_type.unwrap_or_default();
+    let input_size = props.input_size.unwrap_or_default();
 
     rsx!(
         match (props.label, props.required) {
-            (Some(l), Some(_)) => rsx!(
-                label {
-                    class: props.label_class,
-                    "{l} *"
-                }
-            ),
-            (Some(l), None) => rsx!(
-                label {
-                    class: props.label_class,
-                    "{l}"
-                }
-            ),
-            (None, _) => rsx!()
+            (Some(l), Some(_)) => rsx! {
+                label { class: props.label_class, "{l} *" }
+            },
+            (Some(l), None) => rsx! {
+                label { class: props.label_class, "{l}" }
+            },
+            (None, _) => rsx! {},
         }
         input {
             id: props.id,
-            class: "input input-bordered {input_class}",
+            class: "input input-bordered {input_size}",
             value: props.value,
             required: props.required,
             disabled: props.disabled,
@@ -105,14 +87,11 @@ pub fn Input(props: InputProps) -> Element {
             name: "{props.name}",
             placeholder: props.placeholder,
             step: props.step,
-            "type": "{input_type}"
+            "type": "{input_type}",
         }
         if let Some(l) = props.help_text {
             label {
-                span {
-                    class: "label-text-alt",
-                    "{l}"
-                }
+                span { class: "label-text-alt", "{l}" }
             }
         }
     )

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,9 +1,12 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub enum LabelRole {
     #[default]
+    Default,
     Neutral,
     Danger,
     Warning,
@@ -12,15 +15,16 @@ pub enum LabelRole {
     Highlight,
 }
 
-impl LabelRole {
-    pub fn to_string(&self) -> &'static str {
+impl Display for LabelRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LabelRole::Neutral => "label-neutral",
-            LabelRole::Danger => "label-danger",
-            LabelRole::Warning => "label-warning",
-            LabelRole::Success => "label-success",
-            LabelRole::Info => "label-info",
-            LabelRole::Highlight => "label-highlight",
+            LabelRole::Neutral => write!(f, "badge-neutral"),
+            LabelRole::Danger => write!(f, "badge-danger"),
+            LabelRole::Warning => write!(f, "badge-warning"),
+            LabelRole::Success => write!(f, "badge-success"),
+            LabelRole::Info => write!(f, "badge-info"),
+            LabelRole::Highlight => write!(f, "badge-highlight"),
+            LabelRole::Default => write!(f, ""),
         }
     }
 }
@@ -32,11 +36,11 @@ pub enum LabelSize {
     Large,
 }
 
-impl LabelSize {
-    pub fn to_string(&self) -> &'static str {
+impl Display for LabelSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LabelSize::Small => "",
-            LabelSize::Large => "badge-lg",
+            LabelSize::Small => write!(f, ""),
+            LabelSize::Large => write!(f, "badge-lg"),
         }
     }
 }
@@ -51,35 +55,26 @@ pub struct LabelProps {
 
 #[component]
 pub fn Label(props: LabelProps) -> Element {
-    let label_role = if props.label_role.is_some() {
-        props.label_role.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let label_size = if props.label_size.is_some() {
-        props.label_size.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!(
-        "badge {} {} {}",
-        label_role.to_string(),
-        label_size.to_string(),
-        class
-    );
+    let label_role = props.label_role.unwrap_or_default();
+    let label_size = props.label_size.unwrap_or_default();
+    let class = props.class.unwrap_or_default();
 
     rsx!(
-        button {
-            class: "{class}",
-            {props.children},
-        }
+        button { class: "badge {label_role} {label_size} {class}", {props.children} }
     )
+}
+
+#[test]
+fn test_label() {
+    let props = LabelProps {
+        children: rsx!( "Hello" ),
+        class: Some("test".to_string()),
+        label_role: Some(LabelRole::Danger),
+        label_size: Some(LabelSize::Large),
+    };
+
+    let expected = r#"<button class="badge badge-danger badge-lg test">Hello</button>"#;
+    let result = dioxus_ssr::render_element(Label(props));
+    // println!("{}", result);
+    assert_eq!(result, expected);
 }

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -12,25 +12,18 @@ pub struct ModalProps {
 
 #[component]
 pub fn Modal(props: ModalProps) -> Element {
-    let class = if let Some(class) = props.class {
-        format!("modal {}", class)
-    } else {
-        "modal".to_string()
-    };
     rsx!(
         if let Some(action) = &props.submit_action {
-            form {
-                action: "{action}",
-                method: "post",
+            form { action: "{action}", method: "post",
                 dialog {
-                    class: "{class}",
+                    class: "modal {props.class.clone().unwrap_or_default()}",
                     id: "{props.trigger_id}",
                     {props.children}
                 }
             }
         } else {
             dialog {
-                class: "{class}",
+                class: "modal {props.class.clone().unwrap_or_default()}",
                 id: "{props.trigger_id}",
                 {props.children}
             }
@@ -46,18 +39,8 @@ pub struct ModalBodyProps {
 
 #[component]
 pub fn ModalBody(props: ModalBodyProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!("modal-box {}", class);
     rsx!(
-        div {
-            class: "{class}",
-            {props.children}
-        }
+        div { class: "modal-box {props.class.clone().unwrap_or_default()}", {props.children} }
     )
 }
 
@@ -69,17 +52,37 @@ pub struct ModalActionProps {
 
 #[component]
 pub fn ModalAction(props: ModalActionProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
+    rsx!(
+        div { class: "modal-action {props.class.clone().unwrap_or_default()}", {props.children} }
+    )
+}
+
+#[test]
+fn test_modal() {
+    let props = ModalProps {
+        children: rsx!( "Hello" ),
+        class: Some("test".to_string()),
+        submit_action: Some("test".to_string()),
+        trigger_id: "id".to_string(),
     };
 
-    let class = format!("modal-action {}", class);
-    rsx!(
-        div {
-            class: "{class}",
-            {props.children}
-        }
-    )
+    let expected = r#"<form action="test" method="post"><dialog class="modal test" id="id">Hello</dialog></form>"#;
+    let result = dioxus_ssr::render_element(Modal(props));
+    // println!("{}", result);
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn test_modal_without_submit_action() {
+    let props = ModalProps {
+        children: rsx!( "Hello" ),
+        class: Some("test".to_string()),
+        submit_action: None,
+        trigger_id: "id".to_string(),
+    };
+
+    let expected = r#"<dialog class="modal test" id="id">Hello</dialog>"#;
+    let result = dioxus_ssr::render_element(Modal(props));
+    // println!("{}", result);
+    assert_eq!(expected, result);
 }

--- a/src/nav_item.rs
+++ b/src/nav_item.rs
@@ -12,24 +12,17 @@ pub struct NavItemProps {
 
 #[component]
 pub fn NavItem(props: NavItemProps) -> Element {
-    let mut class = "";
-    if let (Some(id), Some(selected_item_id)) = (&props.id, &props.selected_item_id) {
-        if id == selected_item_id {
-            class = "active";
-        }
-    }
+    let class = match (&props.id, &props.selected_item_id) {
+        (Some(id), Some(selected_id)) if id == selected_id => "active",
+        _ => "",
+    };
     rsx!(
-        li {
-            role: "listitem",
+        li { role: "listitem",
             a {
                 class: "{class}",
                 href: "{props.href}",
                 "data-turbo-frame": "main-content",
-                img {
-                    width: "16",
-                    height: "16",
-                    src: "{props.icon}"
-                }
+                img { width: "16", height: "16", src: "{props.icon}" }
                 "{props.title}"
             }
         }
@@ -46,19 +39,14 @@ pub struct NavSubItemProps {
 
 #[component]
 pub fn NavSubItem(props: NavSubItemProps) -> Element {
-    let mut class = "";
-    if let (Some(id), Some(selected_item_id)) = (&props.id, &props.selected_item_id) {
-        if id == selected_item_id {
-            class = "active";
-        }
-    }
+    let class = match (&props.id, &props.selected_item_id) {
+        (Some(id), Some(selected_id)) if id == selected_id => "active",
+        _ => "",
+    };
+
     rsx!(
-        li {
-            class: class,
-            a {
-                href: "{props.href}",
-                "{props.title}"
-            }
+        li { class,
+            a { href: "{props.href}", "{props.title}" }
         }
     )
 }
@@ -72,13 +60,8 @@ pub struct NavGroupProps {
 #[component]
 pub fn NavGroup(props: NavGroupProps) -> Element {
     rsx!(
-        ul {
-            role: "list",
-            class: "menu",
-            li {
-                class: "menu-title",
-                "{props.heading}"
-            }
+        ul { role: "list", class: "menu",
+            li { class: "menu-title", "{props.heading}" }
             {props.content}
         }
     )
@@ -92,10 +75,22 @@ pub struct NavSubGroupProps {
 #[component]
 pub fn NavSubGroup(props: NavSubGroupProps) -> Element {
     rsx!(
-        ul {
-            role: "list",
-            class: "ActionList ActionList--subGroup",
-            {props.children}
-        }
+        ul { role: "list", class: "ActionList ActionList--subGroup", {props.children} }
     )
+}
+
+#[test]
+fn test_nav_item() {
+    let props = NavItemProps {
+        href: "test".to_string(),
+        icon: "test".to_string(),
+        title: "test".to_string(),
+        selected_item_id: Some("test".to_string()),
+        id: Some("test".to_string()),
+    };
+
+    let expected = r#"<li role="listitem"><a class="active" href="test" data-turbo-frame="main-content"><img width="16" height="16" src="test"/>test</a></li>"#;
+    let result = dioxus_ssr::render_element(NavItem(props));
+    // println!("{}", result);
+    assert_eq!(expected, result);
 }

--- a/src/relative_time.rs
+++ b/src/relative_time.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
@@ -12,15 +14,15 @@ pub enum RelativeTimeFormat {
     Elapsed,
 }
 
-impl RelativeTimeFormat {
-    pub fn to_string(&self) -> &'static str {
+impl Display for RelativeTimeFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RelativeTimeFormat::Datetime => "datetime",
-            RelativeTimeFormat::Relative => "relative",
-            RelativeTimeFormat::Duration => "duration",
-            RelativeTimeFormat::Auto => "auto",
-            RelativeTimeFormat::Micro => "micro",
-            RelativeTimeFormat::Elapsed => "elapsed",
+            RelativeTimeFormat::Datetime => write!(f, "datetime"),
+            RelativeTimeFormat::Relative => write!(f, "relative"),
+            RelativeTimeFormat::Duration => write!(f, "duration"),
+            RelativeTimeFormat::Auto => write!(f, "auto"),
+            RelativeTimeFormat::Micro => write!(f, "micro"),
+            RelativeTimeFormat::Elapsed => write!(f, "elapsed"),
         }
     }
 }
@@ -33,17 +35,22 @@ pub struct RelativeTimeProps {
 
 #[component]
 pub fn RelativeTime(props: RelativeTimeProps) -> Element {
-    let format = if props.format.is_some() {
-        props.format.unwrap()
-    } else {
-        Default::default()
-    };
+    let format = props.format.unwrap_or_default();
 
     rsx!(
-        relative
-            - time {
-                datetime: props.datetime,
-                format: format.to_string()
-            }
+        relative-time { datetime: props.datetime, format: format.to_string() }
     )
+}
+
+#[test]
+fn test_relative_time() {
+    let props = RelativeTimeProps {
+        datetime: "2024-01-01".to_string(),
+        format: Some(RelativeTimeFormat::Datetime),
+    };
+
+    let expected = r#"<relative-time datetime="2024-01-01" format="datetime"></relative-time>"#;
+    let result = dioxus_ssr::render_element(RelativeTime(props));
+    // println!("{}", result);
+    assert_eq!(expected, result);
 }

--- a/src/tab_container.rs
+++ b/src/tab_container.rs
@@ -11,17 +11,11 @@ pub struct TabContainerProps {
 
 #[component]
 pub fn TabContainer(props: TabContainerProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
     rsx!(
         div {
             role: "tablist",
-            class: "tabs tabs-bordered {class}",
-            {{props.children}}
+            class: "tabs tabs-bordered {props.class.clone().unwrap_or_default()}",
+            {props.children}
         }
     )
 }
@@ -42,12 +36,8 @@ pub fn TabPanel(props: TabPanelProps) -> Element {
             "type": "radio",
             class: "tab",
             "aria-label": props.tab_name,
-            name: props.name
+            name: props.name,
         }
-        div {
-            role: "tabpanel",
-            class: "tab-content",
-            {{props.children}}
-        }
+        div { role: "tabpanel", class: "tab-content", {props.children} }
     )
 }

--- a/src/time_line.rs
+++ b/src/time_line.rs
@@ -12,24 +12,14 @@ pub struct TimeLineProps {
 
 #[component]
 pub fn TimeLine(props: TimeLineProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let the_class = format!("timeline-item {}", class);
-
-    let class = if props.condensed.is_some() {
-        format!("timeline-condensed {}", the_class)
-    } else {
-        the_class
+    let condensed = match props.condensed {
+        Some(true) => "timeline-condensed",
+        _ => "",
     };
 
     rsx!(
-        div {
-            class: "{class}",
-            {{props.children}}
+        div { class: "{condensed} timeline-item {props.class.clone().unwrap_or_default()}",
+            {props.children}
         }
     )
 }
@@ -42,20 +32,9 @@ pub struct TimeLineBadgeProps {
 
 #[component]
 pub fn TimeLineBadge(props: TimeLineBadgeProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!("timeline-badge {}", class);
     rsx!(
-        div {
-            class: "{class}",
-            img {
-                src: "{props.image_src}",
-                width: "16"
-            }
+        div { class: "timeline-badge {props.class.clone().unwrap_or_default()}",
+            img { src: "{props.image_src}", width: "16" }
         }
     )
 }
@@ -68,18 +47,7 @@ pub struct TimeLineBodyProps {
 
 #[component]
 pub fn TimeLineBody(props: TimeLineBodyProps) -> Element {
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!("timeline-body {}", class);
-
     rsx!(
-        div {
-            class: "{class}",
-            {props.children}
-        }
+        div { class: "timeline-body {props.class.clone().unwrap_or_default()}", {props.children} }
     )
 }

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+use std::fmt::Display;
+
 use dioxus::prelude::*;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -11,14 +13,14 @@ pub enum ToolTipColor {
     Success,
 }
 
-impl ToolTipColor {
-    pub fn to_string(&self) -> &'static str {
+impl Display for ToolTipColor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ToolTipColor::Default => "tooltip tooltip-info",
-            ToolTipColor::Info => "tooltip tooltip-info",
-            ToolTipColor::Warn => "tooltip tooltip-warning",
-            ToolTipColor::Error => "tooltip tooltip-error",
-            ToolTipColor::Success => "tooltip tooltip-success",
+            ToolTipColor::Default => write!(f, ""),
+            ToolTipColor::Info => write!(f, "tooltip-info"),
+            ToolTipColor::Warn => write!(f, "tooltip-warning"),
+            ToolTipColor::Error => write!(f, "tooltip-error"),
+            ToolTipColor::Success => write!(f, "tooltip-success"),
         }
     }
 }
@@ -33,25 +35,10 @@ pub struct ToolTipProps {
 
 #[component]
 pub fn ToolTip(props: ToolTipProps) -> Element {
-    let alert_color = if props.alert_color.is_some() {
-        props.alert_color.unwrap()
-    } else {
-        Default::default()
-    };
-
-    let class = if let Some(class) = props.class {
-        class
-    } else {
-        "".to_string()
-    };
-
-    let class = format!("{} {}", alert_color.to_string(), class);
+    let alert_color = props.alert_color.unwrap_or_default();
+    let class = props.class.unwrap_or_default();
 
     rsx!(
-        div {
-            class: "{class}",
-            "data-tip": props.text,
-            {props.children}
-        }
+        div { class: "tooltip {alert_color} {class}", "data-tip": props.text, {props.children} }
     )
 }


### PR DESCRIPTION
Simplify the codebase by using more idiomatic Rust, to eg. replace complex if-expressions with `unwrap_or_default` and other similar shortcuts.

Replace custom `to_string` functions with implementation of the `Display` trait.

Add some tests to components to verify they produce correct HTML (not very comprehensive).
