### PR TITLE
Implement popover attributes

### DIFF
--- a/src/blank_slate.rs
+++ b/src/blank_slate.rs
@@ -49,7 +49,7 @@ pub fn BlankSlate(props: BlankSlateProps) -> Element {
                     div {
                         Button {
                             button_scheme: ButtonScheme::Primary,
-                            drawer_trigger: "{pa.1}",
+                            popover_target: "{pa.1}",
                             "{pa.0}"
                         }
                     }

--- a/src/button.rs
+++ b/src/button.rs
@@ -72,8 +72,8 @@ pub struct ButtonProps {
     button_type: Option<ButtonType>,
     button_size: Option<ButtonSize>,
     button_scheme: Option<ButtonScheme>,
-    drawer_trigger: Option<String>,
-    modal_trigger: Option<String>,
+    popover_target: Option<String>,
+    popover_target_action: Option<String>,
     disabled_text: Option<String>,
 }
 
@@ -126,8 +126,8 @@ pub fn Button(props: ButtonProps) -> Element {
             class: "{class}",
             id: props.id,
             disabled: disabled,
-            "data-drawer-target": props.drawer_trigger,
-            "data-modal-target": props.modal_trigger,
+            popovertarget: props.popover_target,
+            popovertargetaction: props.popover_target_action,
             "type": "{button_type}",
             "data-disabled-text": props.disabled_text,
             if let Some(img_src) = props.prefix_image_src {

--- a/src/modal.rs
+++ b/src/modal.rs
@@ -25,6 +25,7 @@ pub fn Modal(props: ModalProps) -> Element {
                 dialog {
                     class: "{class}",
                     id: "{props.trigger_id}",
+                    popover: true,
                     {props.children}
                 }
             }
@@ -32,6 +33,7 @@ pub fn Modal(props: ModalProps) -> Element {
             dialog {
                 class: "{class}",
                 id: "{props.trigger_id}",
+                popover: true,
                 {props.children}
             }
         }


### PR DESCRIPTION
## Summary
- add `popover_target` and `popover_target_action` props to `Button`
- use `popovertarget` attributes in rendered button
- use `popover` attribute on `Modal`
- update `BlankSlate` button usage

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68452a4fe9e08320878c1601fdf61b3c