### PR TITLE
Add release GitHub Action and update release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish crate
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches crate version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CRATE_VERSION="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "daisy_rsx") | .version')"
+          if [ "$TAG_VERSION" != "$CRATE_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match crate version ($CRATE_VERSION)."
+            exit 1
+          fi
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Publish to crates.io
+        run: cargo publish --locked

--- a/README.md
+++ b/README.md
@@ -176,18 +176,23 @@ pub fn MyAssistantCard(team_id: i32, prompt: MyPrompt) -> Element {
 
 ## To Create a Release
 
-To create a new release, use the following command locally:
+Release publishing is handled by the GitHub Actions workflow in `.github/workflows/release.yml`. The workflow runs when a tag that starts with `v` (for example, `v0.1.48`) is pushed and will:
+
+- Ensure the tag version matches `Cargo.toml`.
+- Run the test suite.
+- Publish the crate to crates.io using `secrets.CARGO_REGISTRY_TOKEN`.
+
+A typical release flow using [`cargo-release`](https://github.com/crate-ci/cargo-release) looks like this:
 
 ```sh
 cargo install cargo-release
 cargo release patch
 ```
 
-Once you are ready, pass the `--execute` flag.
+The command above performs a dry run. When you are ready to publish, run:
 
-This will:
+```sh
+cargo release patch --execute
+```
 
-- Bump the version number.
-- Create a git tag.
-- Push changes to the remote repository.
-- Trigger the GitHub Actions workflow to publish the crate.
+`cargo-release` will bump the version, create a matching `v*` tag, push the changes, and trigger the release workflow.


### PR DESCRIPTION
### Motivation
- The README referenced a GitHub Actions release workflow that did not exist, so release publishing needed to be automated and documented.
- Ensure releases are consistent and safe by verifying tag versions and running tests before publishing to crates.io.

### Description
- Add `.github/workflows/release.yml` which triggers on pushed tags matching `v*` and on manual `workflow_dispatch`.
- The workflow checks out the repo, sets up the Rust toolchain, caches Cargo, verifies the pushed tag matches the version in `Cargo.toml`, runs `cargo test --locked`, and runs `cargo publish --locked` using `secrets.CARGO_REGISTRY_TOKEN`.
- Update the `README.md` release section to document the new workflow and the recommended `cargo-release` flow including `cargo release patch --execute` to create a matching `v*` tag.

### Testing
- Ran `cargo test --locked` locally and the test suite completed successfully with `24` tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c95a526c832096fc37704ad9df3c)